### PR TITLE
Add mb-metadata to local tool calls

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -79,7 +79,15 @@ export const ChatContent = ({
       if (!localAgent) return undefined;
 
       try {
-        return await executeLocalToolCall(localAgent, toolCall);
+        return await executeLocalToolCall({
+          localAgent,
+          toolCall,
+          metadata: {
+            accountId,
+            evmAddress,
+            chainId,
+          },
+        });
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : "Unknown error";

--- a/src/lib/sign-message.ts
+++ b/src/lib/sign-message.ts
@@ -37,7 +37,6 @@ export const signMessage = async (
       console.error("failed in signMessage", errorMessage);
       throw new Error(errorMessage);
     });
-  console.log("signedMessage", signedMessage);
 
   // Bitte Wallet redirects so signMessage will not have a result
   if (signedMessage) {


### PR DESCRIPTION
Add `accountId`, `evmAddress`, and `chainId` to `mb-metadata` request header on local tool calls.