### PR TITLE
feat: Integrate ApproveButton and DeclineButton in ReviewSignMessage

### DIFF
--- a/src/components/chat/default-components/DefaultTxApproveButton.tsx
+++ b/src/components/chat/default-components/DefaultTxApproveButton.tsx
@@ -5,9 +5,10 @@ const DefaultTxApproveButton: React.FC<TransactionButtonProps> = ({
   onClick,
   disabled,
   isLoading,
+  label,
 }) => (
   <Button className='bitte-w-1/2' onClick={onClick} disabled={disabled}>
-    {isLoading ? "Confirming..." : "Approve"}
+    {isLoading ? "Confirming..." : label || "Approve"}
   </Button>
 );
 

--- a/src/components/chat/default-components/DefaultTxDeclineButton.tsx
+++ b/src/components/chat/default-components/DefaultTxDeclineButton.tsx
@@ -4,6 +4,7 @@ import { Button } from "../../ui/button";
 const DefaultTxDeclineButton: React.FC<TransactionButtonProps> = ({
   onClick,
   disabled,
+  label,
 }) => (
   <Button
     variant='outline'
@@ -11,7 +12,7 @@ const DefaultTxDeclineButton: React.FC<TransactionButtonProps> = ({
     onClick={onClick}
     disabled={disabled}
   >
-    Decline
+    {label || "Decline"}
   </Button>
 );
 

--- a/src/components/chat/transactions/ReviewSignMessage.tsx
+++ b/src/components/chat/transactions/ReviewSignMessage.tsx
@@ -223,20 +223,10 @@ export const ReviewSignMessage = ({
 
       {!loading && !result && !errorMsg ? (
         <CardFooter className='bitte-flex bitte-items-center bitte-gap-6'>
-          <Button
-            variant='outline'
-            className='bitte-w-1/2'
+          <DeclineButton
             onClick={() => addToolResult({ error: "User declined to sign" })}
-          >
-            Decline
-          </Button>
-          <Button
-            variant='default'
-            className='bitte-w-1/2'
-            onClick={handleMessageSign}
-          >
-            Sign Message
-          </Button>
+          />
+          <ApproveButton onClick={handleMessageSign} label='Sign Message' />
         </CardFooter>
       ) : null}
     </TxContainer>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -386,6 +386,7 @@ export interface TransactionButtonProps {
   onClick: () => void;
   disabled?: boolean;
   isLoading?: boolean;
+  label?: string;
 }
 
 // Container props


### PR DESCRIPTION
- Added an optional `label` prop to `TransactionButtonProps`.
- Integrated `ApproveButton` and `DeclineButton`  into the  `ReviewSignMessage` component, to allow customisation. 
- This change aligns with existing functionality in `EvmTxCard` and `ReviewTransaction`.