### PR TITLE
Track bitte wallet transaction hash from url

### DIFF
--- a/src/components/chat/transactions/ReviewTransaction.tsx
+++ b/src/components/chat/transactions/ReviewTransaction.tsx
@@ -1,7 +1,7 @@
 import { Transaction } from "@near-wallet-selector/core";
 import BN from "bn.js";
 import { SafeEncodedSignRequest } from "near-safe";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAccountBalance } from "../../../hooks/useAccountBalance";
 import { SuccessInfo, useTransaction } from "../../../hooks/useTransaction";
 import { useTxnFees } from "../../../hooks/useTxnFees";
@@ -69,6 +69,37 @@ export const ReviewTransaction = ({
 
   const { width } = useWindowSize();
   const isMobile = !!width && width < 640;
+
+  useEffect(() => {
+    if (!result) {
+      const searchParams = new URLSearchParams(window.location.search);
+      const txHash = searchParams.get("transactionHashes");
+
+      if (txHash) {
+        // Create a success info object from the transaction hash
+        const successInfo = {
+          near: {
+            receipts: [
+              {
+                transaction: {
+                  hash: txHash,
+                },
+              },
+            ],
+          },
+        };
+        setResult(successInfo);
+
+        // Clear the URL parameters
+        searchParams.delete("transactionHashes");
+        searchParams.delete("account_id");
+        const newUrl = `${window.location.pathname}${
+          searchParams.toString() ? "?" + searchParams.toString() : ""
+        }`;
+        window.history.replaceState({}, "", newUrl);
+      }
+    }
+  }, [result]);
 
   if (!transactions || transactions.length === 0) {
     return (

--- a/src/hooks/useTransaction.ts
+++ b/src/hooks/useTransaction.ts
@@ -4,10 +4,7 @@ import {
   Wallet,
 } from "@near-wallet-selector/core";
 import { Account } from "near-api-js";
-import {
-  EthTransactionParams,
-  SignRequestData
-} from "near-safe";
+import { EthTransactionParams, SignRequestData } from "near-safe";
 import { EVMWalletAdapter } from "../types";
 
 export interface SuccessInfo {
@@ -81,6 +78,7 @@ export const executeWithAccount = async (
             args: txn.actions[0].params.args,
             attachedDeposit: BigInt(txn.actions[0].params.deposit),
             gas: BigInt(txn.actions[0].params.gas),
+            walletCallbackUrl: window.location.href,
           });
         } catch (error) {
           console.error(
@@ -107,6 +105,7 @@ export const executeWithWallet = async (
   }
   return wallet.signAndSendTransactions({
     transactions: transactions,
+    callbackUrl: window.location.href,
   });
 };
 


### PR DESCRIPTION
This updates the transaction card's state with the result from the `transactionHashes` query param returned by Bitte wallet tx's